### PR TITLE
squashed:

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,9 +5,11 @@ add_executable(example-get-account-info getAccountInfo.cpp)
 add_executable(example-account-subscribe accountSubscribe.cpp)
 add_executable(example-send-transaction sendTransaction.cpp)
 add_executable(example-place-order placeOrder.cpp)
+add_executable(example-orderbook-subscribe orderbookSubscribe.cpp)
 
 # link
 target_link_libraries(example-get-account-info ${CONAN_LIBS} sol)
 target_link_libraries(example-account-subscribe ${CONAN_LIBS} sol)
 target_link_libraries(example-send-transaction ${CONAN_LIBS} sol)
 target_link_libraries(example-place-order ${CONAN_LIBS} sol)
+target_link_libraries(example-orderbook-subscribe ${CONAN_LIBS} sol)

--- a/examples/orderbookSubscribe.cpp
+++ b/examples/orderbookSubscribe.cpp
@@ -1,0 +1,84 @@
+#include <cpr/cpr.h>
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <mutex>
+#include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_client.hpp>
+
+#include "mango_v3.hpp"
+#include "orderbook/levelOne.hpp"
+#include "orderbook/orderbook.hpp"
+#include "solana.hpp"
+#include "subscriptions/bookSide.hpp"
+#include "subscriptions/trades.hpp"
+
+class updateLogger {
+ public:
+  updateLogger(mango_v3::orderbook::book& orderbook,
+               mango_v3::subscription::trades& trades)
+      : orderbook(orderbook), trades(trades) {
+    orderbook.registerUpdateCallback(std::bind(&updateLogger::logUpdate, this));
+    trades.registerUpdateCallback(std::bind(&updateLogger::logUpdate, this));
+  }
+
+  void start() {
+    orderbook.subscribe();
+    trades.subscribe();
+  }
+
+  void logUpdate() {
+    const std::scoped_lock lock(updateMtx);
+    auto level1Snapshot = orderbook.getLevel1();
+    if (level1Snapshot.valid()) {
+      spdlog::info("============Update============");
+      spdlog::info("Latest trade: {}", trades.getLastTrade()
+                                           ? to_string(trades.getLastTrade())
+                                           : "not received yet");
+      spdlog::info("Bid-Ask {}-{}", level1Snapshot.highestBid,
+                   level1Snapshot.lowestAsk);
+      spdlog::info("MidPrice: {}", level1Snapshot.midPoint);
+      spdlog::info("Spread: {0:.2f} bps", level1Snapshot.spreadBps);
+
+      constexpr auto depth = 2;
+      spdlog::info("Market depth -{}%: {}", depth, orderbook.getDepth(-depth));
+      spdlog::info("Market depth +{}%: {}", depth, orderbook.getDepth(depth));
+    }
+  }
+
+ private:
+  std::mutex updateMtx;
+  mango_v3::orderbook::book& orderbook;
+  mango_v3::subscription::trades& trades;
+};
+
+int main() {
+  const auto& config = mango_v3::MAINNET;
+  const solana::rpc::Connection solCon;
+  const auto group = solCon.getAccountInfo<mango_v3::MangoGroup>(config.group);
+
+  const auto symbolIt =
+      std::find(config.symbols.begin(), config.symbols.end(), "SOL");
+  const auto marketIndex = symbolIt - config.symbols.begin();
+  assert(config.symbols[marketIndex] == "SOL");
+
+  const auto perpMarketPk = group.perpMarkets[marketIndex].perpMarket;
+  auto market =
+      solCon.getAccountInfo<mango_v3::PerpMarket>(perpMarketPk.toBase58());
+  assert(market.mangoGroup.toBase58() == config.group);
+
+  mango_v3::subscription::bookSide bids(mango_v3::Buy, market.bids.toBase58());
+  mango_v3::subscription::bookSide asks(mango_v3::Sell, market.asks.toBase58());
+  mango_v3::subscription::trades trades(market.eventQueue.toBase58());
+
+  mango_v3::orderbook::book orderbook(bids, asks);
+
+  updateLogger logger(orderbook, trades);
+  logger.start();
+
+  while (true) {
+  }
+  return 0;
+}
+
+// void updateReceived() {}

--- a/include/mango_v3.hpp
+++ b/include/mango_v3.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <stack>
 #include <string>
 
 #include "fixedp.h"
@@ -15,6 +16,8 @@ const int MAX_PAIRS = 15;
 const int QUOTE_INDEX = 15;
 const int EVENT_SIZE = 200;
 const int EVENT_QUEUE_SIZE = 256;
+const int BOOK_NODE_SIZE = 88;
+const int BOOK_SIZE = 1024;
 
 struct Config {
   std::string endpoint;
@@ -135,8 +138,10 @@ struct EventQueueHeader {
   uint64_t seqNum;
 };
 
+// todo: change to scoped enum class
 enum EventType : uint8_t { Fill, Out, Liquidate };
 
+// todo: change to scoped enum class
 enum Side : uint8_t { Buy, Sell };
 
 struct AnyEvent {
@@ -195,6 +200,93 @@ struct OutEvent {
 struct EventQueue {
   EventQueueHeader header;
   AnyEvent items[EVENT_QUEUE_SIZE];
+};
+
+// todo: change to scoped enum class
+enum NodeType : uint32_t {
+  Uninitialized = 0,
+  InnerNode,
+  LeafNode,
+  FreeNode,
+  LastFreeNode
+};
+
+struct AnyNode {
+  NodeType tag;
+  uint8_t padding[BOOK_NODE_SIZE - 4];
+};
+
+struct InnerNode {
+  NodeType tag;
+  uint32_t prefixLen;
+  __uint128_t key;
+  uint32_t children[2];
+  uint8_t padding[BOOK_NODE_SIZE - 32];
+};
+
+struct LeafNode {
+  NodeType tag;
+  uint8_t ownerSlot;
+  uint8_t orderType;
+  uint8_t version;
+  uint8_t timeInForce;
+  __uint128_t key;
+  solana::PublicKey owner;
+  uint64_t quantity;
+  uint64_t clientOrderId;
+  uint64_t bestInitial;
+  uint64_t timestamp;
+};
+
+struct FreeNode {
+  NodeType tag;
+  uint32_t next;
+  uint8_t padding[BOOK_NODE_SIZE - 8];
+};
+
+struct BookSide {
+  MetaData metaData;
+  uint64_t bumpIndex;
+  uint64_t freeListLen;
+  uint32_t freeListHead;
+  uint32_t rootNode;
+  uint64_t leafCount;
+  AnyNode nodes[BOOK_SIZE];
+
+  struct iterator {
+    Side side;
+    const BookSide &bookSide;
+    std::stack<uint32_t> stack;
+    uint32_t left, right;
+
+    iterator(Side side, const BookSide &bookSide)
+        : side(side), bookSide(bookSide) {
+      stack.push(bookSide.rootNode);
+      left = side == Side::Buy ? 1 : 0;
+      right = side == Side::Buy ? 0 : 1;
+    }
+
+    bool operator==(const iterator &other) const {
+      return &bookSide == &other.bookSide && stack.top() == other.stack.top();
+    }
+
+    iterator &operator++() {
+      if (stack.size() > 0) {
+        const auto &elem = **this;
+        stack.pop();
+
+        if (elem.tag == NodeType::InnerNode) {
+          const auto innerNode =
+              reinterpret_cast<const struct InnerNode *>(&elem);
+          stack.push(innerNode->children[right]);
+          stack.push(innerNode->children[left]);
+        }
+      }
+      return *this;
+    }
+
+    const AnyNode &operator*() const { return bookSide.nodes[stack.top()]; }
+  };
 };
 
 #pragma pack(pop)

--- a/include/orderbook/levelOne.hpp
+++ b/include/orderbook/levelOne.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace mango_v3 {
+namespace orderbook {
+
+struct levelOne {
+  uint64_t highestBid;
+  uint64_t highestBidSize;
+  uint64_t lowestAsk;
+  uint64_t lowestAskSize;
+  double midPoint;
+  double spreadBps;
+
+  bool valid() const {
+    return ((highestBid && lowestAsk) && (lowestAsk > highestBid)) ? true
+                                                                   : false;
+  }
+};
+
+}  // namespace orderbook
+}  // namespace mango_v3

--- a/include/orderbook/order.hpp
+++ b/include/orderbook/order.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace mango_v3 {
+namespace orderbook {
+
+struct order {
+  order(uint64_t price, uint64_t quantity) : price(price), quantity(quantity) {}
+
+  bool operator<(const order& compare) const {
+    return (price < compare.price) ? true : false;
+  }
+
+  bool operator>(const order& compare) const {
+    return (price > compare.price) ? true : false;
+  }
+
+  uint64_t price;
+  uint64_t quantity;
+};
+
+}  // namespace orderbook
+}  // namespace mango_v3

--- a/include/orderbook/orderbook.hpp
+++ b/include/orderbook/orderbook.hpp
@@ -1,0 +1,74 @@
+#pragma once
+#include <spdlog/spdlog.h>
+
+#include <functional>
+#include <mutex>
+
+#include "levelOne.hpp"
+#include "orderbook/order.hpp"
+#include "subscriptions/bookSide.hpp"
+
+namespace mango_v3 {
+namespace orderbook {
+class book {
+ public:
+  book(subscription::bookSide& bids, subscription::bookSide& asks)
+      : bids(bids), asks(asks) {
+    bids.registerUpdateCallback(std::bind(&book::updateCallback, this));
+    asks.registerUpdateCallback(std::bind(&book::updateCallback, this));
+  }
+
+  void registerUpdateCallback(std::function<void()> callback) {
+    onUpdateCb = callback;
+  }
+
+  void subscribe() {
+    bids.subscribe();
+    asks.subscribe();
+  }
+
+  void updateCallback() {
+    const std::scoped_lock lock(callbackMtx);
+    levelOne newL1;
+    auto bestBid = bids.getBestOrder();
+    auto bestAsk = asks.getBestOrder();
+    newL1.highestBid = bestBid.price;
+    newL1.highestBidSize = bestBid.quantity;
+    newL1.lowestAsk = bestAsk.price;
+    newL1.lowestAskSize = bestAsk.quantity;
+
+    if (newL1.valid()) {
+      newL1.midPoint = ((double)newL1.lowestAsk + newL1.highestBid) / 2;
+      newL1.spreadBps =
+          ((newL1.lowestAsk - newL1.highestBid) * 10000) / newL1.midPoint;
+      {
+        const std::scoped_lock lock(levelOneMtx);
+        level1 = newL1;
+      }
+      onUpdateCb();
+    }
+  }
+
+  levelOne getLevel1() const {
+    const std::scoped_lock lock(levelOneMtx);
+    return level1;
+  }
+
+  uint64_t getDepth(int8_t percent) {
+    const std::scoped_lock lock(levelOneMtx);
+    auto price = (level1.midPoint * (100 + percent)) / 100;
+    return (percent > 0) ? asks.getVolume<std::less_equal<uint64_t>>(price)
+                         : bids.getVolume<std::greater_equal<uint64_t>>(price);
+  }
+
+ private:
+  levelOne level1;
+  // todo:macos latomic not found issue, otherwise replace mtx with std::atomic
+  mutable std::mutex levelOneMtx;
+  std::function<void()> onUpdateCb;
+  std::mutex callbackMtx;
+  subscription::bookSide& bids;
+  subscription::bookSide& asks;
+};
+}  // namespace orderbook
+}  // namespace mango_v3

--- a/include/solana.hpp
+++ b/include/solana.hpp
@@ -250,7 +250,8 @@ class Connection {
   ///
   json getAccountInfoRequest(const std::string &account,
                              const std::string &encoding = "base64",
-                             const size_t offset = 0, const size_t length = 0);
+                             const size_t offset = 0,
+                             const size_t length = 0) const;
   json getRecentBlockhashRequest(const std::string &commitment = "finalized");
   json sendTransactionRequest(
       const std::string &transaction, const std::string &encoding = "base58",
@@ -269,7 +270,8 @@ class Connection {
   template <typename T>
   inline T getAccountInfo(const std::string &account,
                           const std::string &encoding = "base64",
-                          const size_t offset = 0, const size_t length = 0) {
+                          const size_t offset = 0,
+                          const size_t length = 0) const {
     const json req = getAccountInfoRequest(account, encoding, offset, length);
     cpr::Response r =
         cpr::Post(cpr::Url{rpc_url_}, cpr::Body{req.dump()},

--- a/include/subscriptions/bookSide.hpp
+++ b/include/subscriptions/bookSide.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <functional>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+#include "mango_v3.hpp"
+#include "orderbook/order.hpp"
+#include "solana.hpp"
+#include "wssSubscriber.hpp"
+
+namespace mango_v3 {
+namespace subscription {
+
+using json = nlohmann::json;
+
+class bookSide {
+ public:
+  bookSide(Side side, const std::string& account)
+      : side(side), wssConnection(account) {}
+
+  void registerUpdateCallback(std::function<void()> callback) {
+    notifyCb = callback;
+  }
+
+  void subscribe() {
+    wssConnection.registerOnMessageCallback(
+        std::bind(&bookSide::onMessage, this, std::placeholders::_1));
+    wssConnection.start();
+  }
+
+  orderbook::order getBestOrder() const {
+    std::scoped_lock lock(ordersMtx);
+    return (!orders.empty()) ? orders.front() : orderbook::order{0, 0};
+  }
+
+  template <typename Op>
+  uint64_t getVolume(uint64_t price) const {
+    Op operation;
+    uint64_t volume = 0;
+    std::scoped_lock lock(ordersMtx);
+    for (auto&& order : orders) {
+      if (operation(order.price, price)) {
+        volume += order.quantity;
+      } else {
+        break;
+      }
+    }
+    return volume;
+  }
+
+ private:
+  void onMessage(const json& parsedMsg) {
+    // ignore subscription confirmation
+    const auto itResult = parsedMsg.find("result");
+    if (itResult != parsedMsg.end()) {
+      spdlog::info("on_result {}", parsedMsg.dump());
+      return;
+    }
+
+    const std::string encoded =
+        parsedMsg["params"]["result"]["value"]["data"][0];
+
+    const std::string decoded = solana::b64decode(encoded);
+    if (decoded.size() != sizeof(BookSide))
+      throw std::runtime_error("invalid response length " +
+                               std::to_string(decoded.size()) + " expected " +
+                               std::to_string(sizeof(BookSide)));
+
+    BookSide bookSide;
+    memcpy(&bookSide, decoded.data(), sizeof(decltype(bookSide)));
+
+    auto iter = BookSide::iterator(side, bookSide);
+
+    decltype(orders) newOrders;
+
+    while (iter.stack.size() > 0) {
+      if ((*iter).tag == NodeType::LeafNode) {
+        const auto leafNode =
+            reinterpret_cast<const struct LeafNode*>(&(*iter));
+        const auto now = std::chrono::system_clock::now();
+        const auto nowUnix =
+            chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch())
+                .count();
+        const auto isValid =
+            !leafNode->timeInForce ||
+            leafNode->timestamp + leafNode->timeInForce < nowUnix;
+        if (isValid) {
+          newOrders.emplace_back((uint64_t)(leafNode->key >> 64),
+                                 leafNode->quantity);
+        }
+      }
+      ++iter;
+    }
+
+    if (!newOrders.empty()) {
+      {
+        std::scoped_lock lock(ordersMtx);
+        orders = std::move(newOrders);
+        if (side == Side::Buy) {
+          std::sort(orders.begin(), orders.end(), std::greater{});
+        } else {
+          std::sort(orders.begin(), orders.end());
+        }
+      }
+      notifyCb();
+    }
+  }
+
+  wssSubscriber wssConnection;
+  const Side side;
+  mutable std::mutex ordersMtx;
+  std::vector<orderbook::order> orders;
+  std::function<void()> notifyCb;
+};
+}  // namespace subscription
+}  // namespace mango_v3

--- a/include/subscriptions/trades.hpp
+++ b/include/subscriptions/trades.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <functional>
+#include <nlohmann/json.hpp>
+
+#include "mango_v3.hpp"
+#include "solana.hpp"
+#include "wssSubscriber.hpp"
+
+namespace mango_v3 {
+namespace subscription {
+
+using json = nlohmann::json;
+
+class trades {
+ public:
+  trades(const std::string &account) : wssConnection(account) {}
+
+  void registerUpdateCallback(std::function<void()> callback) {
+    notifyCb = callback;
+  }
+
+  void subscribe() {
+    wssConnection.registerOnMessageCallback(
+        std::bind(&trades::onMessage, this, std::placeholders::_1));
+    wssConnection.start();
+  }
+
+  int64_t getLastTrade() const {
+    const std::scoped_lock lock(latestTradeMtx);
+    return latestTrade;
+  }
+
+ private:
+  void onMessage(const json &parsedMsg) {
+    // ignore subscription confirmation
+    const auto itResult = parsedMsg.find("result");
+    if (itResult != parsedMsg.end()) {
+      spdlog::info("on_result {}", parsedMsg.dump());
+      return;
+    }
+
+    // all other messages are event queue updates
+    const std::string method = parsedMsg["method"];
+    const int subscription = parsedMsg["params"]["subscription"];
+    const int slot = parsedMsg["params"]["result"]["context"]["slot"];
+    const std::string data = parsedMsg["params"]["result"]["value"]["data"][0];
+
+    const auto decoded = solana::b64decode(data);
+    const auto events = reinterpret_cast<const EventQueue *>(decoded.data());
+    const auto seqNumDiff = events->header.seqNum - lastSeqNum;
+    const auto lastSlot =
+        (events->header.head + events->header.count) % EVENT_QUEUE_SIZE;
+
+    bool gotLatest = false;
+    if (events->header.seqNum > lastSeqNum) {
+      for (int offset = seqNumDiff; offset > 0; --offset) {
+        const auto slot =
+            (lastSlot - offset + EVENT_QUEUE_SIZE) % EVENT_QUEUE_SIZE;
+        const auto &event = events->items[slot];
+
+        if (event.eventType == EventType::Fill) {
+          const auto &fill = (FillEvent &)event;
+          const std::scoped_lock lock(latestTradeMtx);
+          latestTrade = fill.price;
+          gotLatest = true;
+        }
+        // no break; let's iterate to the last fill to get the latest fill order
+      }
+    }
+
+    if (gotLatest) {
+      notifyCb();
+    }
+    lastSeqNum = events->header.seqNum;
+  }
+
+  uint64_t lastSeqNum = INT_MAX;
+  // todo:macos latomic not found issue, otherwise replace mtx with std::atomic
+  mutable std::mutex latestTradeMtx;
+  uint64_t latestTrade = 0;
+  wssSubscriber wssConnection;
+  std::function<void()> notifyCb;
+};
+}  // namespace subscription
+}  // namespace mango_v3

--- a/include/subscriptions/wssSubscriber.hpp
+++ b/include/subscriptions/wssSubscriber.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <functional>
+#include <thread>
+#include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_client.hpp>
+
+typedef websocketpp::client<websocketpp::config::asio_tls_client> ws_client;
+typedef websocketpp::config::asio_client::message_type::ptr ws_message_ptr;
+typedef std::shared_ptr<boost::asio::ssl::context> context_ptr;
+
+namespace mango_v3 {
+namespace subscription {
+
+using json = nlohmann::json;
+
+class wssSubscriber {
+ public:
+  wssSubscriber(const std::string& account) : account(account) {}
+
+  ~wssSubscriber() { runThread.join(); }
+
+  void registerOnMessageCallback(
+      std::function<void(const json& message)> callback) {
+    onMessageCb = callback;
+  }
+
+  void start() {
+    runThread = std::thread(&wssSubscriber::subscriptionThread, this);
+  }
+
+ private:
+  void subscriptionThread() {
+    try {
+      c.set_access_channels(websocketpp::log::alevel::all);
+      c.init_asio();
+      c.set_tls_init_handler(
+          websocketpp::lib::bind(&wssSubscriber::on_tls_init, this));
+
+      c.set_open_handler(websocketpp::lib::bind(
+          &wssSubscriber::on_open, this, websocketpp::lib::placeholders::_1));
+      c.set_message_handler(websocketpp::lib::bind(
+          &wssSubscriber::on_message, this, websocketpp::lib::placeholders::_1,
+          websocketpp::lib::placeholders::_2));
+
+      websocketpp::lib::error_code ec;
+      ws_client::connection_ptr con = c.get_connection(
+          "wss://mango.rpcpool.com/946ef7337da3f5b8d3e4a34e7f88", ec);
+      if (ec) {
+        spdlog::error("could not create connection because: {}", ec.message());
+      }
+      c.connect(con);
+      c.run();
+    } catch (websocketpp::exception const& e) {
+      std::cout << e.what() << std::endl;
+    }
+  }
+
+  context_ptr on_tls_init() {
+    context_ptr ctx = std::make_shared<boost::asio::ssl::context>(
+        boost::asio::ssl::context::sslv23);
+
+    try {
+      ctx->set_options(boost::asio::ssl::context::default_workarounds |
+                       boost::asio::ssl::context::no_sslv2 |
+                       boost::asio::ssl::context::no_sslv3 |
+                       boost::asio::ssl::context::single_dh_use);
+    } catch (std::exception& e) {
+      spdlog::error("Error in context pointer: {}", e.what());
+    }
+    return ctx;
+  }
+
+  void on_open(websocketpp::connection_hdl hdl) {
+    websocketpp::lib::error_code ec;
+
+    c.send(hdl,
+           solana::rpc::subscription::accountSubscribeRequest(account).dump(),
+           websocketpp::frame::opcode::value::text, ec);
+    if (ec) {
+      spdlog::error("subscribe failed because: {}", ec.message());
+    } else {
+      spdlog::info("subscribed to account {}", account);
+    }
+  }
+
+  void on_message(websocketpp::connection_hdl hdl, ws_message_ptr msg) {
+    const json parsedMsg = json::parse(msg->get_payload());
+    onMessageCb(parsedMsg);
+  }
+
+  ws_client c;
+  const std::string account;
+  std::thread runThread;
+  std::function<void(const json&)> onMessageCb;
+};
+}  // namespace subscription
+}  // namespace mango_v3

--- a/lib/solana.cpp
+++ b/lib/solana.cpp
@@ -20,7 +20,7 @@ Connection::Connection(const std::string &rpc_url,
 json Connection::getAccountInfoRequest(const std::string &account,
                                        const std::string &encoding,
                                        const size_t offset,
-                                       const size_t length) {
+                                       const size_t length) const {
   json params = {account};
   json options = {{"encoding", encoding}};
   if (offset && length) {


### PR DESCRIPTION
initial example adapted from max
getting lowest ask
using wss to subscribe to bids and asks
moved the subscription code to own class for reuse
added orderbook class which takes book sides and logs the info on updates from either of the book side
added a reusable class for wss boilerplate and a subscription class for trade event queue
refactored the example so the subscription classes can be reused by other clients
atomic snapshot for orderbook struct to avoid potential data race
using bsp instead of bps. atomic variables for bookside and added empty calls for book depth
getting all leaf nodes and sorting them as per prices
const correctness at solana api
added market depth logic
further refactoring
midpoint double
replaced atomic with mtx due to issues at macos, can be investigated later
simplified the fill reception callback